### PR TITLE
Refresh contributing docs and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,126 @@
+# AGENTS.md
+
+Guidance for AI agents working on the Klokku codebase.
+
+## Project Overview
+
+Klokku is a time-planning and time-tracking application written in Go.
+The repository produces two binaries:
+
+- `klokku` - the HTTP API server (`main.go`, built with `make build`).
+- `klokku-cli` - a Cobra-based CLI for interacting with the API, primarily aimed at AI agents and scripting (`cmd/klokku-cli/main.go` -> `internal/cli/`, built with `make build-cli`).
+
+The frontend lives in a separate repository (`klokku-ui`) and is optionally served by the Go backend when `frontend.enabled` is true.
+
+## Tech Stack
+
+- **Language**: Go 1.26+ (module path `github.com/klokku/klokku`).
+- **Database**: PostgreSQL 18, accessed via `pgx/v5` connection pool.
+- **Migrations**: `golang-migrate` v4, files in `/migrations` (numbered `NNNN_description.up.sql` / `.down.sql`).
+- **HTTP**: Gorilla Mux.
+- **Config**: koanf (YAML + `KLOKKU_`-prefixed env vars), defined in `internal/config/config.go`.
+- **Logging**: logrus, imported as `log`.
+- **API docs**: Swagger via `swag`/`http-swagger`; generated docs live in `/docs` and are served at `/swagger/`.
+- **Testing**: testify (assert/require); repository tests use `testcontainers-go` with a real Postgres container.
+
+## Common Commands
+
+```bash
+make build           # build the klokku server binary
+make build-cli       # build the klokku-cli binary
+make build-all       # build both
+make run             # go run main.go
+
+make fmt             # go fmt
+make vet             # go vet (runs fmt first)
+make cilint          # golangci-lint run (CI uses v2.11.3, --timeout=10m)
+make swagger         # regenerate Swagger docs from annotations (run after changing handlers)
+
+go test ./... -v     # run all tests (requires Docker for repository tests)
+go test ./pkg/<pkg>/... -v -run TestServiceImpl_GetPlan   # run a specific test
+```
+
+Lint and tests must pass before committing. CI runs `go test ./... -v` and `golangci-lint`.
+
+## Repository Tests Require Docker
+
+Repository-level tests spin up a real Postgres container via testcontainers (see `internal/test_utils/postgres.go`).
+Docker must be running. The container is snapshotted after migrations and restored between tests for isolation.
+Service-level tests do NOT need Docker - they use in-memory stub repositories (e.g. `repository_stub.go`).
+Prefer stubs for business-logic tests; use testcontainers only when you are testing SQL/repository behavior.
+
+## Architecture
+
+See `contributing/architecture.md` and `contributing/guidelines.md` for the full style guide. Key points:
+
+- `/pkg/` - public domain packages, organized by feature (`budget_plan`, `calendar`, `current_event`, `stats`, `user`, `weekly_plan`, `webhook`, `clickup`, `calendar_provider`, `budget_plan_report`). Each is importable by other projects.
+- `/internal/` - private code: `app` (wiring, routes, middleware), `config`, `database`, `event_bus`, `rest` (HTTP helpers), `cli` (CLI commands), `test_utils`, `utils`.
+- `/migrations/` - golang-migrate up/down SQL files.
+- `/db/init.sql` - full schema for fresh DB installs (Docker Compose and testcontainers init).
+- `/contributing/`, `/docs/`, `/scripts/`, `/skills/` - supporting files.
+
+Each domain package follows a strict four-file layering:
+
+1. `<domain>.go` - domain models (plain structs, no logic).
+2. `repository.go` - `Repository` interface + `RepositoryImpl` using `*pgxpool.Pool`, constructed by `NewRepository(db)`.
+3. `service.go` - `Service` interface + `ServiceImpl`, constructed by `NewService(repo, ...)`. Business logic lives here; it reads the current user from context via `user.CurrentId(ctx)`.
+4. `handler.go` - HTTP `Handler` struct with methods wired to routes, constructed by `NewHandler(svc)`; methods carry `// @Summary` Swagger annotations.
+
+Testing files: `service_test.go` (stub-based) and `repository_test.go` (testcontainers-based) alongside the implementation.
+
+## Authentication
+
+There is no token-based auth. The `X-User-Id` header carries a user UID.
+The middleware in `internal/app/middleware.go` resolves it to a `user.User` and stores it in the request context (`user.WithUser`).
+Services obtain the user with `user.CurrentId(ctx)` or `user.Current(ctx)`; always propagate `context.Context` as the first parameter.
+When adding an endpoint that needs the current user, do not read the header yourself - read the context.
+
+## Wiring: Adding a New Feature / Endpoint
+
+Follow the existing pattern end-to-end:
+
+1. **Domain model**: add structs to `pkg/<domain>/<domain>.go`.
+2. **Repository**: define methods on the `Repository` interface and implement them in `repository.go` using prepared statements/parameterized queries. Add a stub implementation in `repository_stub.go` if service tests need it.
+3. **Service**: add methods to the `Service` interface and `ServiceImpl` in `service.go`. Inject dependencies via the constructor; do not create them inside.
+4. **Handler**: add HTTP methods to `Handler` in `handler.go` with Swagger annotations.
+5. **Wiring**: instantiate the new repo/service/handler in `internal/app/dependencies.go` `BuildDependencies` and add fields to the `Dependencies` struct.
+6. **Routes**: register the route in `internal/app/routes.go` under the `/api/...` prefix.
+7. **Swagger**: run `make swagger` to regenerate `/docs` after adding/changing annotations. Commit the regenerated `docs/docs.go`, `docs/swagger.json`, `docs/swagger.yaml`.
+8. **Migrations** (if schema changes): add `migrations/NNNN_description.up.sql` and `.down.sql`, AND mirror the change in `db/init.sql` so fresh installs and testcontainers stay consistent. Both must always agree.
+9. **Tests**: add table-driven tests. Use stubs in `service_test.go` for logic; use testcontainers in `repository_test.go` for SQL. Name tests `Test<Type>_<Scenario>`.
+
+## Conventions (from `contributing/guidelines.md`)
+
+- Singular package names (`user`, not `users`).
+- Exported CamelCase, unexported camelCase; acronyms as words (`HttpServer`).
+- Methods: action verbs (`GetAll`, `Store`, `Update`); `FindX` returns `X, error` (nil-able), `GetX` returns collections.
+- Interfaces at top of file, then implementations; small focused interfaces.
+- Error handling: wrap with `fmt.Errorf("...: %w", err)`; define typed errors (e.g. `ErrUserNotFound`); log with context; never `panic` in production code; early returns to reduce nesting.
+- No naked returns in long functions; no global state; prefer immutability.
+- Context as first parameter for any I/O function.
+- Database: prepared statements, parameterized queries, `sql.Null*` / pgx nullable types for nullable columns, `defer` for resource cleanup, transactions for atomic operations.
+- Comments: self-documenting code first; add comments only for non-obvious context. Package comment in at least one file per package.
+
+## CLI (`klokku-cli`)
+
+Cobra-based; entry point `cmd/klokku-cli/main.go` delegates to `internal/cli/cmd`.
+REST client code lives under `internal/cli/api`, output formatting under `internal/cli/output`, config under `internal/cli/config`.
+The `skills/klokku-cli/SKILL.md` file documents CLI usage for AI agents and should be kept in sync with CLI commands.
+Released via GoReleaser (`.goreleaser.yaml`) on unprefixed Git tags.
+
+## Git Workflow
+
+- Target branch: `main`.
+- Branch naming prefixes: `feature/`, `bugfix/`, `tech/`, `upgrade/` (e.g. `feature/budget-plan-report`).
+- PRs are squash-merged; the resulting commit message uses imperative mood and ends with `(#NN)` referencing the PR number (e.g. `Add budget plan report feature (#27)`).
+- Write commit/PR messages in the imperative ("Add ...", "Fix ...", "Update ...").
+- Do not force-push to `main`; never force-push shared branches.
+- Never commit secrets or the `.env` file (it is gitignored).
+
+## Before Opening a PR
+
+1. `make fmt && make vet`
+2. `make cilint` (or `golangci-lint run`)
+3. `go test ./... -v` (Docker running)
+4. `make swagger` if you touched handlers, and commit regenerated docs.
+5. Confirm migrations + `db/init.sql` agree if you changed the schema.

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -1,58 +1,115 @@
 # Architecture
 
-Klokku follows a clean architecture pattern with clear separation of concerns between different layers:
+Klokku follows a clean architecture pattern with clear separation of concerns between different layers.
 
 ## Technology Stack
-- **Backend**: Go (Golang)
-- **Database**: Postgres with migrations managed by golang-migrate
+- **Backend**: Go 1.26+ (module `github.com/klokku/klokku`)
+- **Database**: PostgreSQL 18, accessed via `pgx/v5`; migrations managed by `golang-migrate` v4
 - **Web Framework**: Gorilla Mux for HTTP routing
-- **Frontend**: [React application](https://github.com/klokku/klokku-ui), optionally served by the Go backend
-- **External Integrations**: 
-  - Google Calendar API
+- **Configuration**: koanf (YAML file + `KLOKKU_`-prefixed env vars)
+- **Logging**: logrus (imported as `log`)
+- **API Docs**: Swagger via `swag`/`http-swagger`, served at `/swagger/`
+- **Frontend**: [React application](https://github.com/klokku/klokku-ui) (`klokku-ui`), optionally served by the Go backend when `frontend.enabled` is true
+- **External Integrations**:
+    - ClickUp (OAuth-based task integration)
+    - Google Calendar API (calendar provider option; currently disabled at runtime)
 
 ## Application Layers
 1. **Domain Layer**: Contains the core business entities and logic
-    - Domain models (e.g., Budget, Event, User)
+    - Domain models (e.g., `BudgetPlan`, `Event`, `User`)
     - Business rules and validations
 
 2. **Repository Layer**: Handles data access and persistence
-    - Database operations
+    - Database operations via `pgx/v5` connection pool
     - Data mapping between domain models and database schema
     - Transaction management
 
 3. **Service Layer**: Implements business logic and orchestrates operations
     - Business workflows
     - Integration with external services
-    - Authorization and validation
+    - Authorization and validation (reads the current user from context)
 
 4. **API Layer**: Handles HTTP requests and responses
     - Request parsing and validation
     - Response formatting
     - Error handling
-    - Authentication middleware
+    - Authentication middleware (resolves `X-User-Id` header into request context)
 
 ## Key Design Patterns
 - **Dependency Injection**: Components receive their dependencies through constructors
 - **Repository Pattern**: Data access is abstracted behind interfaces
 - **DTO Pattern**: Data Transfer Objects separate API representation from domain models
 - **Middleware**: HTTP request processing pipeline for cross-cutting concerns
+- **Event Bus**: An in-process event bus (`internal/event_bus`) notifies services of changes (e.g. current event changes, budget plan updates)
+- **Calendar Provider**: `calendar_provider.CalendarProvider` abstracts over multiple calendar backends, selecting one per user based on their settings
 
 ## Project Structure
-- `/pkg/`: Contains the core packages of the application
-    - `/budget/`: Budget management functionality
-    - `/event/`: Event tracking functionality
-    - `/user/`: User management functionality
-    - `/stats/`: Statistics generation functionality
-    - `/google/`: Google Calendar integration
-- `/internal/`: Internal packages not meant for external use
-- `/migrations/`: Database migration scripts
-- `/storage/`: Data storage location
-- `/contributing/`: Contribution guidelines
+
+### `/pkg/` - public domain packages, organized by feature
+Each package is importable by other projects and follows the four-file layering described in the "Domain Package Layout" section below.
+- `budget_plan` - budget plans and budget items management
+- `budget_plan_report` - reports comparing budget plans against tracked time
+- `calendar` - Klokku's built-in calendar and event management
+- `calendar_provider` - selects the active calendar backend for the current user
+- `clickup` - ClickUp OAuth integration, task sync, and per-budget-plan configuration
+- `current_event` - the currently running time-tracking event
+- `stats` - weekly and historical statistics
+- `user` - users, settings, and context propagation helpers
+- `webhook` - incoming webhooks (creation, listing, execution) used to drive current-event changes
+- `weekly_plan` - weekly plan items derived from budget plans
+
+### `/internal/` - private code not meant for external use
+- `app` - application wiring: `app.go` (lifecycle), `dependencies.go` (DI graph), `routes.go` (route registration), `middleware.go` (auth + context propagation)
+- `cli` - `klokku-cli` Cobra commands; REST client under `cli/api`, output formatting under `cli/output`, config under `cli/config`
+- `config` - koanf-based configuration loading
+- `database` - Postgres connection pool and migration runner
+- `event_bus` - in-process event bus shared across services
+- `rest` - HTTP helpers (error responses, frontend handler)
+- `test_utils` - testcontainers Postgres setup and user-related test helpers
+- `utils` - small shared utilities (e.g. `Clock` abstraction)
+
+### Other directories
+- `/migrations/` - golang-migrate up/down SQL files, numbered `NNNN_description.up.sql` / `.down.sql`
+- `/db/init.sql` - full schema for fresh DB installs (Docker Compose and testcontainers init); must stay in sync with `/migrations/`
+- `/docs/` - generated Swagger docs (`docs.go`, `swagger.json`, `swagger.yaml`); regenerated by `make swagger`
+- `/cmd/klokku-cli/` - CLI entry point (delegates to `internal/cli/cmd`)
+- `/scripts/` - install scripts (`install.sh`, `install.ps1`)
+- `/contributing/` - architecture and style guide documents
+- `/skills/` - AI agent skill for `klokku-cli` usage
+- `/storage/` - runtime data storage location (gitignored)
+- `/ui/` - frontend build output used when serving the UI from the Go backend (gitignored)
+
+## Domain Package Layout
+
+Each domain package in `/pkg/` follows a strict four-file layering:
+
+1. `<domain>.go` - domain models (plain structs, no logic)
+2. `repository.go` - `Repository` interface + `RepositoryImpl` using `*pgxpool.Pool`, constructed by `NewRepository(db)`
+3. `service.go` - `Service` interface + `ServiceImpl`, constructed by `NewService(repo, ...)`; business logic lives here and reads the current user from context via `user.CurrentId(ctx)`
+4. `handler.go` - HTTP `Handler` struct with methods wired to routes, constructed by `NewHandler(svc)`; methods carry `// @Summary` Swagger annotations
+
+Testing files live alongside the implementation:
+- `service_test.go` - stub-based business-logic tests (no Docker needed)
+- `repository_test.go` - testcontainers-based SQL tests (requires Docker)
+- `repository_stub.go` / other stubs - in-memory stub implementations used by service tests
 
 ## API Design
-The application exposes a RESTful API for frontend communication, with endpoints for:
-- User management
-- Budget management
-- Event tracking
-- Statistics generation
-- Google Calendar integration
+
+The application exposes a RESTful API under the `/api/...` prefix for frontend and CLI communication, with endpoints for:
+- User management and settings
+- Budget plan and budget item management
+- Weekly plan management
+- Current event tracking
+- Calendar events (Klokku calendar)
+- Statistics (weekly and item history)
+- Webhook management and execution
+- Budget plan reports
+- ClickUp integration (OAuth, workspaces, spaces, folders, tags, configuration, tasks)
+
+Routes are registered in `internal/app/routes.go`. Swagger UI is served at `/swagger/index.html` when the application is running.
+
+## CLI (`klokku-cli`)
+
+A Cobra-based CLI in `cmd/klokku-cli/` (delegating to `internal/cli/cmd`) for interacting with the API.
+Designed primarily for AI agents and scripting, released via GoReleaser on unprefixed Git tags.
+The `skills/klokku-cli/SKILL.md` file documents CLI usage for AI agents and should be kept in sync with CLI commands.

--- a/contributing/guidelines.md
+++ b/contributing/guidelines.md
@@ -16,11 +16,12 @@ This document outlines the coding conventions and best practices for Go developm
 
 ## Package Organization
 
-- **Domain-Driven Design**: Organize packages by domain/feature (e.g., `budget`, `event`, `user`).
+- **Domain-Driven Design**: Organize packages by domain/feature (e.g., `budget_plan`, `current_event`, `user`).
 - **Separation of Concerns**: Use the following package hierarchy:
-  - `internal/`: Code that's not meant to be imported by other projects
-  - `pkg/`: Code that can be imported by other projects
-  - `migrations/`: Database migration scripts
+  - `internal/`: Code that's not meant for external import (app wiring, config, database, CLI, test utils)
+  - `pkg/`: Code that can be imported by other projects; each package follows the four-file layering (model, repository, service, handler) described in `contributing/architecture.md`
+  - `migrations/`: Database migration scripts (golang-migrate, numbered `NNNN_description.up.sql` / `.down.sql`)
+  - `db/init.sql`: Full schema for fresh installs; must stay in sync with `/migrations/`
 - **Package Naming**: Use singular nouns for package names (e.g., `user` not `users`).
 - **Avoid Circular Dependencies**: Ensure packages form a directed acyclic graph.
 
@@ -52,9 +53,9 @@ This document outlines the coding conventions and best practices for Go developm
 
 ## Error Handling
 
-- **Error Wrapping**: Prefer `errors` from the standard library to create and inspect errors. Use `fmt.Errorf` sparingly for additional context and chaining with `%w`.
+- **Error Wrapping**: Wrap errors with `fmt.Errorf("context: %w", err)` to add context as errors propagate up the call stack. Use `errors.Is` / `errors.As` to inspect wrapped errors.
+- **Typed Errors**: Define sentinel error variables with `errors.New` for specific error conditions (e.g., `ErrUserNotFound`, `ErrNoCurrentEvent`, `ErrPlanNotFound`). Package-prefix them with `Err` and place them near the top of the relevant file.
 - **Error Propagation**: Return errors to the caller rather than handling them locally when appropriate.
-- **Custom Errors**: Define custom error variables for specific error conditions (e.g., `ErrNoCurrentEvent`).
 - **Early Returns**: Use early returns for error conditions to minimize nesting.
 - **Logging**: Log errors with context before returning them.
 - **No Panic**: Avoid using `panic` in production code; return errors instead.
@@ -68,8 +69,11 @@ This document outlines the coding conventions and best practices for Go developm
 
 ## Testing
 
-- **Table-Driven Tests**: Use table-driven tests for testing multiple scenarios.
-- **Mocking**: Use interfaces and dependency injection to facilitate mocking.
+- **Table-Driven Tests**: Use table-driven tests for testing multiple scenarios, with `t.Run` subtests.
+- **Two-Layer Testing**:
+    - `service_test.go` - stub-based tests for business logic; no Docker required. Use in-memory stub repositories (e.g. `repository_stub.go`).
+    - `repository_test.go` - testcontainers-based tests for SQL/repository behavior; requires Docker. The Postgres container is snapshotted after migrations and restored between tests for isolation (see `internal/test_utils/postgres.go`).
+- **Mocking**: Use interfaces and dependency injection to facilitate stubbing; prefer stub implementations over mocks.
 - **Test Naming**: Name tests with the pattern `Test<Function>_<Scenario>`.
 - **Test Coverage**: Aim to test critical paths and edge cases thoroughly. Avoid focusing solely on coverage metrics; instead, prioritize meaningful, high-value tests for complex and critical logic.
 
@@ -83,11 +87,13 @@ This document outlines the coding conventions and best practices for Go developm
 
 ## Database Access
 
+- **Driver**: PostgreSQL via `pgx/v5` (connection pool `*pgxpool.Pool`); repositories are constructed with `NewRepository(db)`.
 - **Prepared Statements**: Use prepared statements for all database operations.
-- **Resource Cleanup**: Use `defer` to ensure resources are properly closed.
-- **Transaction Management**: Use transactions for operations that require atomicity.
+- **Resource Cleanup**: Use `defer` to ensure resources (rows, connections) are properly closed.
+- **Transaction Management**: Use transactions (`pgx.Tx`) for operations that require atomicity; roll back on error (checking `pgx.ErrTxClosed`).
 - **SQL Injection Prevention**: Use parameterized queries to prevent SQL injection.
-- **NULL Handling**: Use `sql.Null*` types for columns that can be NULL.
+- **NULL Handling**: Use `sql.Null*` types (or pgx nullable types) for columns that can be NULL.
+- **No Rows**: Detect missing rows with `errors.Is(err, pgx.ErrNoRows)`.
 
 ## Common Pitfalls
 


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with guidance for AI agents: project overview, tech stack, commands, testcontainers requirements, architecture, domain package layout, authentication, the 9-step wiring checklist for new endpoints, conventions, CLI, and git workflow.
- Refresh `contributing/architecture.md` to reflect the current codebase: complete tech stack (pgx/v5, koanf, logrus, Swagger, ClickUp), all 10 `pkg/` domain packages and `internal/` subpackages, the four-file domain package layout, event bus, calendar provider, CLI, and updated API endpoint list.
- Update `contributing/guidelines.md` to match actual conventions: fix stale package examples, correct error-handling guidance to endorse `fmt.Errorf` wrapping, add pgx/v5 database access details, and document the two-layer testing split (stub-based vs testcontainers).

## Motivation

The existing `architecture.md` referenced packages that no longer exist (`budget`, `event`, `google`) and was missing pgx/v5, the event bus, the calendar provider, and the CLI. The `guidelines.md` had error-handling advice (`use fmt.Errorf sparingly`) that directly contradicted the pervasive wrapping pattern used across the codebase. `AGENTS.md` did not exist, leaving AI agents without structured onboarding context for the repo.