### PR TITLE
Add budget plan duplication feature

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -256,6 +256,69 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/budgetplan/{planId}/duplicate": {
+            "post": {
+                "description": "Create a copy of an existing budget plan with all its items under a new name",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BudgetPlan"
+                ],
+                "summary": "Duplicate a budget plan with all its items",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Budget Plan ID",
+                        "name": "planId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New plan name",
+                        "name": "plan",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/budget_plan.BudgetPlanDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "XUserId": []
+                    }
+                ]
+            }
+        },
         "/api/budgetplan/{planId}/item": {
             "post": {
                 "description": "Register a new budget item within a specific budget plan",
@@ -491,6 +554,129 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Item Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "XUserId": []
+                    }
+                ]
+            }
+        },
+        "/api/budgetplan/{planId}/report": {
+            "get": {
+                "description": "Retrieve report for a budget plan. Without from/to params returns full lifetime data. With from/to returns data for the specified period.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BudgetPlanReport"
+                ],
+                "summary": "Get budget plan report",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Budget Plan ID",
+                        "name": "planId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date in RFC3339 format (must be provided together with 'to')",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date in RFC3339 format (must be provided together with 'from')",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/budget_plan_report.ReportDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "XUserId": []
+                    }
+                ]
+            }
+        },
+        "/api/budgetplan/{planId}/report/item/{itemId}": {
+            "get": {
+                "description": "Retrieve detailed statistics, weekly breakdown, daily breakdown, and day-of-week averages for a single budget plan item.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BudgetPlanReport"
+                ],
+                "summary": "Get detailed report for a single budget plan item",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Budget Plan ID",
+                        "name": "planId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Budget Item ID",
+                        "name": "itemId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date in RFC3339 format (must be provided together with 'to')",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date in RFC3339 format (must be provided together with 'from')",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/budget_plan_report.ItemDetailReportDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "type": "string"
                         }
@@ -2214,6 +2400,69 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/weeklyplan/off-week": {
+            "put": {
+                "description": "Mark or unmark a week as an off-week. Off-weeks are excluded from budget plan reports.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WeeklyPlan"
+                ],
+                "summary": "Set off-week flag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Date in RFC3339 format (can be any day of the week)",
+                        "name": "date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Off-week flag",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "isOffWeek": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/weekly_plan.WeeklyPlanDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "XUserId": []
+                    }
+                ]
+            }
+        },
         "/webhook/{token}": {
             "post": {
                 "description": "Execute a webhook action using the webhook token (no authentication required)",
@@ -2301,6 +2550,291 @@ const docTemplate = `{
                 },
                 "weeklyOccurrences": {
                     "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.DayOfWeekEntryDTO": {
+            "type": "object",
+            "properties": {
+                "averageTime": {
+                    "type": "integer"
+                },
+                "dayOfWeek": {
+                    "type": "integer"
+                },
+                "totalTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.HourlyHeatmapEntryDTO": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "dayOfWeek": {
+                    "type": "integer"
+                },
+                "hour": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.ItemDayEntryDTO": {
+            "type": "object",
+            "properties": {
+                "actualTime": {
+                    "type": "integer"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "dayOfWeek": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.ItemDetailReportDTO": {
+            "type": "object",
+            "properties": {
+                "activeDaysCount": {
+                    "type": "integer"
+                },
+                "averagePerActiveDay": {
+                    "type": "integer"
+                },
+                "averagePerDay": {
+                    "type": "integer"
+                },
+                "averagePerWeek": {
+                    "type": "integer"
+                },
+                "completionPercent": {
+                    "type": "number"
+                },
+                "dayOfWeekAvg": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.DayOfWeekEntryDTO"
+                    }
+                },
+                "days": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.ItemDayEntryDTO"
+                    }
+                },
+                "endDate": {
+                    "type": "string"
+                },
+                "excludedWeekCount": {
+                    "type": "integer"
+                },
+                "hourlyHeatmap": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.HourlyHeatmapEntryDTO"
+                    }
+                },
+                "itemColor": {
+                    "type": "string"
+                },
+                "itemIcon": {
+                    "type": "string"
+                },
+                "itemId": {
+                    "type": "integer"
+                },
+                "itemName": {
+                    "type": "string"
+                },
+                "medianPerActiveDay": {
+                    "type": "integer"
+                },
+                "medianPerDay": {
+                    "type": "integer"
+                },
+                "medianPerWeek": {
+                    "type": "integer"
+                },
+                "overBudgetTime": {
+                    "type": "integer"
+                },
+                "planId": {
+                    "type": "integer"
+                },
+                "planName": {
+                    "type": "string"
+                },
+                "remainingTime": {
+                    "type": "integer"
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "totalActualTime": {
+                    "type": "integer"
+                },
+                "totalBudgetPlanTime": {
+                    "type": "integer"
+                },
+                "totalDaysCount": {
+                    "type": "integer"
+                },
+                "totalWeeklyPlanTime": {
+                    "type": "integer"
+                },
+                "weekCount": {
+                    "type": "integer"
+                },
+                "weeks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.ItemWeekEntryDTO"
+                    }
+                }
+            }
+        },
+        "budget_plan_report.ItemWeekEntryDTO": {
+            "type": "object",
+            "properties": {
+                "actualTime": {
+                    "type": "integer"
+                },
+                "budgetPlanTime": {
+                    "type": "integer"
+                },
+                "endDate": {
+                    "type": "string"
+                },
+                "isOffWeek": {
+                    "type": "boolean"
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "weekNumber": {
+                    "type": "string"
+                },
+                "weeklyPlanTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.ReportDTO": {
+            "type": "object",
+            "properties": {
+                "endDate": {
+                    "type": "string"
+                },
+                "excludedWeekCount": {
+                    "type": "integer"
+                },
+                "planId": {
+                    "type": "integer"
+                },
+                "planName": {
+                    "type": "string"
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "totals": {
+                    "$ref": "#/definitions/budget_plan_report.ReportTotalsDTO"
+                },
+                "weekCount": {
+                    "type": "integer"
+                },
+                "weeks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.WeeklyReportEntryDTO"
+                    }
+                }
+            }
+        },
+        "budget_plan_report.ReportItemDTO": {
+            "type": "object",
+            "properties": {
+                "actualTime": {
+                    "type": "integer"
+                },
+                "averagePerDay": {
+                    "type": "integer"
+                },
+                "averagePerWeek": {
+                    "type": "integer"
+                },
+                "budgetItemId": {
+                    "type": "integer"
+                },
+                "budgetPlanTime": {
+                    "type": "integer"
+                },
+                "color": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "integer"
+                },
+                "weeklyPlanTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.ReportTotalsDTO": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.ReportItemDTO"
+                    }
+                },
+                "totalActualTime": {
+                    "type": "integer"
+                },
+                "totalBudgetPlanTime": {
+                    "type": "integer"
+                },
+                "totalWeeklyPlanTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.WeeklyReportEntryDTO": {
+            "type": "object",
+            "properties": {
+                "endDate": {
+                    "type": "string"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.ReportItemDTO"
+                    }
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "totalActualTime": {
+                    "type": "integer"
+                },
+                "totalBudgetPlanTime": {
+                    "type": "integer"
+                },
+                "totalWeeklyPlanTime": {
+                    "type": "integer"
+                },
+                "weekNumber": {
+                    "type": "string"
                 }
             }
         },
@@ -2672,6 +3206,9 @@ const docTemplate = `{
             "properties": {
                 "budgetPlanId": {
                     "type": "integer"
+                },
+                "isOffWeek": {
+                    "type": "boolean"
                 },
                 "items": {
                     "type": "array",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -250,6 +250,69 @@
                 ]
             }
         },
+        "/api/budgetplan/{planId}/duplicate": {
+            "post": {
+                "description": "Create a copy of an existing budget plan with all its items under a new name",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BudgetPlan"
+                ],
+                "summary": "Duplicate a budget plan with all its items",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Budget Plan ID",
+                        "name": "planId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New plan name",
+                        "name": "plan",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/budget_plan.BudgetPlanDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "XUserId": []
+                    }
+                ]
+            }
+        },
         "/api/budgetplan/{planId}/item": {
             "post": {
                 "description": "Register a new budget item within a specific budget plan",
@@ -485,6 +548,129 @@
                     },
                     "404": {
                         "description": "Item Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "XUserId": []
+                    }
+                ]
+            }
+        },
+        "/api/budgetplan/{planId}/report": {
+            "get": {
+                "description": "Retrieve report for a budget plan. Without from/to params returns full lifetime data. With from/to returns data for the specified period.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BudgetPlanReport"
+                ],
+                "summary": "Get budget plan report",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Budget Plan ID",
+                        "name": "planId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date in RFC3339 format (must be provided together with 'to')",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date in RFC3339 format (must be provided together with 'from')",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/budget_plan_report.ReportDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "XUserId": []
+                    }
+                ]
+            }
+        },
+        "/api/budgetplan/{planId}/report/item/{itemId}": {
+            "get": {
+                "description": "Retrieve detailed statistics, weekly breakdown, daily breakdown, and day-of-week averages for a single budget plan item.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BudgetPlanReport"
+                ],
+                "summary": "Get detailed report for a single budget plan item",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Budget Plan ID",
+                        "name": "planId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Budget Item ID",
+                        "name": "itemId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date in RFC3339 format (must be provided together with 'to')",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date in RFC3339 format (must be provided together with 'from')",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/budget_plan_report.ItemDetailReportDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "type": "string"
                         }
@@ -2208,6 +2394,69 @@
                 ]
             }
         },
+        "/api/weeklyplan/off-week": {
+            "put": {
+                "description": "Mark or unmark a week as an off-week. Off-weeks are excluded from budget plan reports.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WeeklyPlan"
+                ],
+                "summary": "Set off-week flag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Date in RFC3339 format (can be any day of the week)",
+                        "name": "date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Off-week flag",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "isOffWeek": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/weekly_plan.WeeklyPlanDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "XUserId": []
+                    }
+                ]
+            }
+        },
         "/webhook/{token}": {
             "post": {
                 "description": "Execute a webhook action using the webhook token (no authentication required)",
@@ -2295,6 +2544,291 @@
                 },
                 "weeklyOccurrences": {
                     "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.DayOfWeekEntryDTO": {
+            "type": "object",
+            "properties": {
+                "averageTime": {
+                    "type": "integer"
+                },
+                "dayOfWeek": {
+                    "type": "integer"
+                },
+                "totalTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.HourlyHeatmapEntryDTO": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "dayOfWeek": {
+                    "type": "integer"
+                },
+                "hour": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.ItemDayEntryDTO": {
+            "type": "object",
+            "properties": {
+                "actualTime": {
+                    "type": "integer"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "dayOfWeek": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.ItemDetailReportDTO": {
+            "type": "object",
+            "properties": {
+                "activeDaysCount": {
+                    "type": "integer"
+                },
+                "averagePerActiveDay": {
+                    "type": "integer"
+                },
+                "averagePerDay": {
+                    "type": "integer"
+                },
+                "averagePerWeek": {
+                    "type": "integer"
+                },
+                "completionPercent": {
+                    "type": "number"
+                },
+                "dayOfWeekAvg": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.DayOfWeekEntryDTO"
+                    }
+                },
+                "days": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.ItemDayEntryDTO"
+                    }
+                },
+                "endDate": {
+                    "type": "string"
+                },
+                "excludedWeekCount": {
+                    "type": "integer"
+                },
+                "hourlyHeatmap": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.HourlyHeatmapEntryDTO"
+                    }
+                },
+                "itemColor": {
+                    "type": "string"
+                },
+                "itemIcon": {
+                    "type": "string"
+                },
+                "itemId": {
+                    "type": "integer"
+                },
+                "itemName": {
+                    "type": "string"
+                },
+                "medianPerActiveDay": {
+                    "type": "integer"
+                },
+                "medianPerDay": {
+                    "type": "integer"
+                },
+                "medianPerWeek": {
+                    "type": "integer"
+                },
+                "overBudgetTime": {
+                    "type": "integer"
+                },
+                "planId": {
+                    "type": "integer"
+                },
+                "planName": {
+                    "type": "string"
+                },
+                "remainingTime": {
+                    "type": "integer"
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "totalActualTime": {
+                    "type": "integer"
+                },
+                "totalBudgetPlanTime": {
+                    "type": "integer"
+                },
+                "totalDaysCount": {
+                    "type": "integer"
+                },
+                "totalWeeklyPlanTime": {
+                    "type": "integer"
+                },
+                "weekCount": {
+                    "type": "integer"
+                },
+                "weeks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.ItemWeekEntryDTO"
+                    }
+                }
+            }
+        },
+        "budget_plan_report.ItemWeekEntryDTO": {
+            "type": "object",
+            "properties": {
+                "actualTime": {
+                    "type": "integer"
+                },
+                "budgetPlanTime": {
+                    "type": "integer"
+                },
+                "endDate": {
+                    "type": "string"
+                },
+                "isOffWeek": {
+                    "type": "boolean"
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "weekNumber": {
+                    "type": "string"
+                },
+                "weeklyPlanTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.ReportDTO": {
+            "type": "object",
+            "properties": {
+                "endDate": {
+                    "type": "string"
+                },
+                "excludedWeekCount": {
+                    "type": "integer"
+                },
+                "planId": {
+                    "type": "integer"
+                },
+                "planName": {
+                    "type": "string"
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "totals": {
+                    "$ref": "#/definitions/budget_plan_report.ReportTotalsDTO"
+                },
+                "weekCount": {
+                    "type": "integer"
+                },
+                "weeks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.WeeklyReportEntryDTO"
+                    }
+                }
+            }
+        },
+        "budget_plan_report.ReportItemDTO": {
+            "type": "object",
+            "properties": {
+                "actualTime": {
+                    "type": "integer"
+                },
+                "averagePerDay": {
+                    "type": "integer"
+                },
+                "averagePerWeek": {
+                    "type": "integer"
+                },
+                "budgetItemId": {
+                    "type": "integer"
+                },
+                "budgetPlanTime": {
+                    "type": "integer"
+                },
+                "color": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "integer"
+                },
+                "weeklyPlanTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.ReportTotalsDTO": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.ReportItemDTO"
+                    }
+                },
+                "totalActualTime": {
+                    "type": "integer"
+                },
+                "totalBudgetPlanTime": {
+                    "type": "integer"
+                },
+                "totalWeeklyPlanTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "budget_plan_report.WeeklyReportEntryDTO": {
+            "type": "object",
+            "properties": {
+                "endDate": {
+                    "type": "string"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/budget_plan_report.ReportItemDTO"
+                    }
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "totalActualTime": {
+                    "type": "integer"
+                },
+                "totalBudgetPlanTime": {
+                    "type": "integer"
+                },
+                "totalWeeklyPlanTime": {
+                    "type": "integer"
+                },
+                "weekNumber": {
+                    "type": "string"
                 }
             }
         },
@@ -2666,6 +3200,9 @@
             "properties": {
                 "budgetPlanId": {
                     "type": "integer"
+                },
+                "isOffWeek": {
+                    "type": "boolean"
                 },
                 "items": {
                     "type": "array",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -28,6 +28,193 @@ definitions:
       weeklyOccurrences:
         type: integer
     type: object
+  budget_plan_report.DayOfWeekEntryDTO:
+    properties:
+      averageTime:
+        type: integer
+      dayOfWeek:
+        type: integer
+      totalTime:
+        type: integer
+    type: object
+  budget_plan_report.HourlyHeatmapEntryDTO:
+    properties:
+      count:
+        type: integer
+      dayOfWeek:
+        type: integer
+      hour:
+        type: integer
+    type: object
+  budget_plan_report.ItemDayEntryDTO:
+    properties:
+      actualTime:
+        type: integer
+      date:
+        type: string
+      dayOfWeek:
+        type: integer
+    type: object
+  budget_plan_report.ItemDetailReportDTO:
+    properties:
+      activeDaysCount:
+        type: integer
+      averagePerActiveDay:
+        type: integer
+      averagePerDay:
+        type: integer
+      averagePerWeek:
+        type: integer
+      completionPercent:
+        type: number
+      dayOfWeekAvg:
+        items:
+          $ref: '#/definitions/budget_plan_report.DayOfWeekEntryDTO'
+        type: array
+      days:
+        items:
+          $ref: '#/definitions/budget_plan_report.ItemDayEntryDTO'
+        type: array
+      endDate:
+        type: string
+      excludedWeekCount:
+        type: integer
+      hourlyHeatmap:
+        items:
+          $ref: '#/definitions/budget_plan_report.HourlyHeatmapEntryDTO'
+        type: array
+      itemColor:
+        type: string
+      itemIcon:
+        type: string
+      itemId:
+        type: integer
+      itemName:
+        type: string
+      medianPerActiveDay:
+        type: integer
+      medianPerDay:
+        type: integer
+      medianPerWeek:
+        type: integer
+      overBudgetTime:
+        type: integer
+      planId:
+        type: integer
+      planName:
+        type: string
+      remainingTime:
+        type: integer
+      startDate:
+        type: string
+      totalActualTime:
+        type: integer
+      totalBudgetPlanTime:
+        type: integer
+      totalDaysCount:
+        type: integer
+      totalWeeklyPlanTime:
+        type: integer
+      weekCount:
+        type: integer
+      weeks:
+        items:
+          $ref: '#/definitions/budget_plan_report.ItemWeekEntryDTO'
+        type: array
+    type: object
+  budget_plan_report.ItemWeekEntryDTO:
+    properties:
+      actualTime:
+        type: integer
+      budgetPlanTime:
+        type: integer
+      endDate:
+        type: string
+      isOffWeek:
+        type: boolean
+      startDate:
+        type: string
+      weekNumber:
+        type: string
+      weeklyPlanTime:
+        type: integer
+    type: object
+  budget_plan_report.ReportDTO:
+    properties:
+      endDate:
+        type: string
+      excludedWeekCount:
+        type: integer
+      planId:
+        type: integer
+      planName:
+        type: string
+      startDate:
+        type: string
+      totals:
+        $ref: '#/definitions/budget_plan_report.ReportTotalsDTO'
+      weekCount:
+        type: integer
+      weeks:
+        items:
+          $ref: '#/definitions/budget_plan_report.WeeklyReportEntryDTO'
+        type: array
+    type: object
+  budget_plan_report.ReportItemDTO:
+    properties:
+      actualTime:
+        type: integer
+      averagePerDay:
+        type: integer
+      averagePerWeek:
+        type: integer
+      budgetItemId:
+        type: integer
+      budgetPlanTime:
+        type: integer
+      color:
+        type: string
+      icon:
+        type: string
+      name:
+        type: string
+      position:
+        type: integer
+      weeklyPlanTime:
+        type: integer
+    type: object
+  budget_plan_report.ReportTotalsDTO:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/budget_plan_report.ReportItemDTO'
+        type: array
+      totalActualTime:
+        type: integer
+      totalBudgetPlanTime:
+        type: integer
+      totalWeeklyPlanTime:
+        type: integer
+    type: object
+  budget_plan_report.WeeklyReportEntryDTO:
+    properties:
+      endDate:
+        type: string
+      items:
+        items:
+          $ref: '#/definitions/budget_plan_report.ReportItemDTO'
+        type: array
+      startDate:
+        type: string
+      totalActualTime:
+        type: integer
+      totalBudgetPlanTime:
+        type: integer
+      totalWeeklyPlanTime:
+        type: integer
+      weekNumber:
+        type: string
+    type: object
   calendar.EventDTO:
     properties:
       budgetItemId:
@@ -268,6 +455,8 @@ definitions:
     properties:
       budgetPlanId:
         type: integer
+      isOffWeek:
+        type: boolean
       items:
         items:
           $ref: '#/definitions/weekly_plan.WeeklyPlanItemDTO'
@@ -454,6 +643,47 @@ paths:
       summary: Update an existing budget plan
       tags:
       - BudgetPlan
+  /api/budgetplan/{planId}/duplicate:
+    post:
+      consumes:
+      - application/json
+      description: Create a copy of an existing budget plan with all its items under
+        a new name
+      parameters:
+      - description: Budget Plan ID
+        in: path
+        name: planId
+        required: true
+        type: integer
+      - description: New plan name
+        in: body
+        name: plan
+        required: true
+        schema:
+          properties:
+            name:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/budget_plan.BudgetPlanDTO'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "403":
+          description: User not found
+          schema:
+            type: string
+      security:
+      - XUserId: []
+      summary: Duplicate a budget plan with all its items
+      tags:
+      - BudgetPlan
   /api/budgetplan/{planId}/item:
     post:
       consumes:
@@ -613,6 +843,89 @@ paths:
       summary: Set position of a budget item
       tags:
       - BudgetItem
+  /api/budgetplan/{planId}/report:
+    get:
+      description: Retrieve report for a budget plan. Without from/to params returns
+        full lifetime data. With from/to returns data for the specified period.
+      parameters:
+      - description: Budget Plan ID
+        in: path
+        name: planId
+        required: true
+        type: integer
+      - description: Start date in RFC3339 format (must be provided together with
+          'to')
+        in: query
+        name: from
+        type: string
+      - description: End date in RFC3339 format (must be provided together with 'from')
+        in: query
+        name: to
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/budget_plan_report.ReportDTO'
+        "400":
+          description: Invalid parameters
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - XUserId: []
+      summary: Get budget plan report
+      tags:
+      - BudgetPlanReport
+  /api/budgetplan/{planId}/report/item/{itemId}:
+    get:
+      description: Retrieve detailed statistics, weekly breakdown, daily breakdown,
+        and day-of-week averages for a single budget plan item.
+      parameters:
+      - description: Budget Plan ID
+        in: path
+        name: planId
+        required: true
+        type: integer
+      - description: Budget Item ID
+        in: path
+        name: itemId
+        required: true
+        type: integer
+      - description: Start date in RFC3339 format (must be provided together with
+          'to')
+        in: query
+        name: from
+        type: string
+      - description: End date in RFC3339 format (must be provided together with 'from')
+        in: query
+        name: to
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/budget_plan_report.ItemDetailReportDTO'
+        "400":
+          description: Invalid parameters
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - XUserId: []
+      summary: Get detailed report for a single budget plan item
+      tags:
+      - BudgetPlanReport
   /api/calendar/event:
     get:
       description: Retrieve calendar events within a date range
@@ -1703,6 +2016,47 @@ paths:
       security:
       - XUserId: []
       summary: Reset a weekly plan item
+      tags:
+      - WeeklyPlan
+  /api/weeklyplan/off-week:
+    put:
+      consumes:
+      - application/json
+      description: Mark or unmark a week as an off-week. Off-weeks are excluded from
+        budget plan reports.
+      parameters:
+      - description: Date in RFC3339 format (can be any day of the week)
+        in: query
+        name: date
+        required: true
+        type: string
+      - description: Off-week flag
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            isOffWeek:
+              type: boolean
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/weekly_plan.WeeklyPlanDTO'
+        "400":
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "403":
+          description: User not found
+          schema:
+            type: string
+      security:
+      - XUserId: []
+      summary: Set off-week flag
       tags:
       - WeeklyPlan
   /webhook/{token}:

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -20,6 +20,7 @@ func RegisterRoutes(r *mux.Router, deps *Dependencies, cfg config.Application) {
 	r.HandleFunc("/api/budgetplan/{planId}", deps.BudgetPlanHandler.GetPlan).Methods("GET")
 	r.HandleFunc("/api/budgetplan/{planId}", deps.BudgetPlanHandler.UpdatePlan).Methods("PUT")
 	r.HandleFunc("/api/budgetplan/{planId}", deps.BudgetPlanHandler.DeletePlan).Methods("DELETE")
+	r.HandleFunc("/api/budgetplan/{planId}/duplicate", deps.BudgetPlanHandler.DuplicatePlan).Methods("POST")
 
 	// Budget Item
 	r.HandleFunc("/api/budgetplan/{planId}/item", deps.BudgetPlanHandler.RegisterItem).Methods("POST")

--- a/pkg/budget_plan/handler.go
+++ b/pkg/budget_plan/handler.go
@@ -99,6 +99,60 @@ func (handler *Handler) CreatePlan(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// DuplicatePlan godoc
+// @Summary Duplicate a budget plan with all its items
+// @Description Create a copy of an existing budget plan with all its items under a new name
+// @Tags BudgetPlan
+// @Accept json
+// @Produce json
+// @Param planId path int true "Budget Plan ID"
+// @Param plan body object{name=string} true "New plan name"
+// @Success 201 {object} BudgetPlanDTO
+// @Failure 400 {string} string "Bad Request"
+// @Failure 403 {string} string "User not found"
+// @Router /api/budgetplan/{planId}/duplicate [post]
+// @Security XUserId
+func (handler *Handler) DuplicatePlan(w http.ResponseWriter, r *http.Request) {
+	log.Debug("Duplicating budget plan")
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	planIdString := vars["planId"]
+	planId, err := strconv.Atoi(planIdString)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	plan, err := handler.service.DuplicatePlan(r.Context(), planId, req.Name)
+	if err != nil {
+		if errors.Is(err, ErrPlanNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, ErrPlanNameEmpty) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	planDTO := PlanToDTO(plan)
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(planDTO); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
 // UpdatePlan godoc
 // @Summary Update an existing budget plan
 // @Description Update a budget plan by ID

--- a/pkg/budget_plan/repository.go
+++ b/pkg/budget_plan/repository.go
@@ -15,6 +15,7 @@ import (
 var ErrPlanNotFound = errors.New("plan not found")
 var ErrDeletingCurrentPlan = errors.New("cannot delete current plan")
 var ErrBudgetPlanItemNotFound = errors.New("budget plan item not found")
+var ErrPlanNameEmpty = errors.New("plan name cannot be empty")
 
 type Repository interface {
 	StoreItem(ctx context.Context, userId int, budget BudgetItem) (int, int, error)
@@ -22,6 +23,7 @@ type Repository interface {
 	GetCurrentPlan(ctx context.Context, userId int) (BudgetPlan, error)
 	ListPlans(ctx context.Context, userId int) ([]BudgetPlan, error)
 	CreatePlan(ctx context.Context, userId int, plan BudgetPlan) (BudgetPlan, error)
+	DuplicatePlan(ctx context.Context, userId int, sourcePlanId int, newName string) (BudgetPlan, error)
 	UpdatePlan(ctx context.Context, userId int, plan BudgetPlan) (BudgetPlan, error)
 	DeletePlan(ctx context.Context, userId int, planId int) (bool, error)
 	GetItem(ctx context.Context, userId int, itemId int) (BudgetItem, error)
@@ -280,6 +282,51 @@ func (r *RepositoryImpl) CreatePlan(ctx context.Context, userId int, plan Budget
 	}
 
 	return BudgetPlan{Id: planId, Name: plan.Name}, nil
+}
+
+func (r *RepositoryImpl) DuplicatePlan(ctx context.Context, userId int, sourcePlanId int, newName string) (BudgetPlan, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return BudgetPlan{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var sourceExists bool
+	err = tx.QueryRow(ctx, `SELECT true FROM budget_plan WHERE id = $1 AND user_id = $2`, sourcePlanId, userId).Scan(&sourceExists)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return BudgetPlan{}, ErrPlanNotFound
+		}
+		err := fmt.Errorf("could not verify source plan: %w", err)
+		log.Error(err)
+		return BudgetPlan{}, err
+	}
+
+	var newPlanId int
+	query := `INSERT INTO budget_plan (name, user_id) VALUES ($1, $2) RETURNING id`
+	err = tx.QueryRow(ctx, query, newName, userId).Scan(&newPlanId)
+	if err != nil {
+		err := fmt.Errorf("could not insert duplicated plan: %w", err)
+		log.Error(err)
+		return BudgetPlan{}, err
+	}
+
+	query = `INSERT INTO budget_item (budget_plan_id, name, weekly_duration_sec, weekly_occurrences, icon, color, position, user_id)
+		SELECT $1, name, weekly_duration_sec, weekly_occurrences, icon, color, position, user_id
+		FROM budget_item
+		WHERE budget_plan_id = $2 AND user_id = $3`
+	_, err = tx.Exec(ctx, query, newPlanId, sourcePlanId, userId)
+	if err != nil {
+		err := fmt.Errorf("could not copy items: %w", err)
+		log.Error(err)
+		return BudgetPlan{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return BudgetPlan{}, fmt.Errorf("could not commit transaction: %w", err)
+	}
+
+	return BudgetPlan{Id: newPlanId, Name: newName}, nil
 }
 
 func (r *RepositoryImpl) UpdatePlan(ctx context.Context, userId int, plan BudgetPlan) (BudgetPlan, error) {

--- a/pkg/budget_plan/repository_stub.go
+++ b/pkg/budget_plan/repository_stub.go
@@ -25,6 +25,30 @@ func (s *RepositoryStub) CreatePlan(ctx context.Context, userId int, plan Budget
 	return plan, nil
 }
 
+func (s *RepositoryStub) DuplicatePlan(ctx context.Context, userId int, sourcePlanId int, newName string) (BudgetPlan, error) {
+	sourcePlan, exists := s.plans[sourcePlanId]
+	if !exists {
+		return BudgetPlan{}, ErrPlanNotFound
+	}
+
+	s.nextId++
+	newPlan := BudgetPlan{
+		Id:        s.nextId,
+		Name:      newName,
+		IsCurrent: false,
+		Items:     make([]BudgetItem, 0, len(sourcePlan.Items)),
+	}
+	for _, item := range sourcePlan.Items {
+		s.nextId++
+		copiedItem := item
+		copiedItem.Id = s.nextId
+		copiedItem.PlanId = newPlan.Id
+		newPlan.Items = append(newPlan.Items, copiedItem)
+	}
+	s.plans[newPlan.Id] = newPlan
+	return newPlan, nil
+}
+
 func (s *RepositoryStub) GetCurrentPlan(ctx context.Context, userId int) (BudgetPlan, error) {
 	if s.currentPlanId == 0 {
 		return BudgetPlan{}, ErrPlanNotFound

--- a/pkg/budget_plan/repository_test.go
+++ b/pkg/budget_plan/repository_test.go
@@ -438,3 +438,97 @@ func TestRepositoryImpl_GetItem(t *testing.T) {
 	assert.Equal(t, "#DDDDFF", item.Color)
 	assert.Equal(t, "some-icon", item.Icon)
 }
+
+func TestRepositoryImpl_DuplicatePlan(t *testing.T) {
+	t.Run("should duplicate plan with all items", func(t *testing.T) {
+		// given
+		ctx, repo, userId := setupTestRepository(t)
+		sourcePlan, _ := repo.CreatePlan(ctx, userId, BudgetPlan{Name: "Source Plan"})
+		repo.StoreItem(ctx, userId, BudgetItem{PlanId: sourcePlan.Id, Name: "Item 1", WeeklyDuration: time.Hour, WeeklyOccurrences: 3, Icon: "icon1", Color: "#FF0000"})
+		repo.StoreItem(ctx, userId, BudgetItem{PlanId: sourcePlan.Id, Name: "Item 2", WeeklyDuration: 2 * time.Hour, WeeklyOccurrences: 5, Icon: "icon2", Color: "#00FF00"})
+
+		// when
+		duplicated, err := repo.DuplicatePlan(ctx, userId, sourcePlan.Id, "Duplicated Plan")
+
+		// then
+		assert.NoError(t, err)
+		assert.NotEqual(t, sourcePlan.Id, duplicated.Id)
+		assert.Equal(t, "Duplicated Plan", duplicated.Name)
+
+		storedDuplicated, _ := repo.GetPlan(ctx, userId, duplicated.Id)
+		assert.Len(t, storedDuplicated.Items, 2)
+		assert.Equal(t, "Item 1", storedDuplicated.Items[0].Name)
+		assert.Equal(t, time.Hour, storedDuplicated.Items[0].WeeklyDuration)
+		assert.Equal(t, 3, storedDuplicated.Items[0].WeeklyOccurrences)
+		assert.Equal(t, "icon1", storedDuplicated.Items[0].Icon)
+		assert.Equal(t, "#FF0000", storedDuplicated.Items[0].Color)
+		assert.NotEqual(t, 0, storedDuplicated.Items[0].Id)
+		assert.Equal(t, "Item 2", storedDuplicated.Items[1].Name)
+		assert.Equal(t, 2*time.Hour, storedDuplicated.Items[1].WeeklyDuration)
+		assert.Equal(t, 5, storedDuplicated.Items[1].WeeklyOccurrences)
+		assert.Equal(t, "icon2", storedDuplicated.Items[1].Icon)
+		assert.Equal(t, "#00FF00", storedDuplicated.Items[1].Color)
+
+		source, _ := repo.GetPlan(ctx, userId, sourcePlan.Id)
+		assert.Len(t, source.Items, 2, "source plan items should be unchanged")
+	})
+
+	t.Run("should duplicate plan with no items", func(t *testing.T) {
+		// given
+		ctx, repo, userId := setupTestRepository(t)
+		sourcePlan, _ := repo.CreatePlan(ctx, userId, BudgetPlan{Name: "Empty Plan"})
+
+		// when
+		duplicated, err := repo.DuplicatePlan(ctx, userId, sourcePlan.Id, "Duplicated Empty")
+
+		// then
+		assert.NoError(t, err)
+		assert.NotEqual(t, sourcePlan.Id, duplicated.Id)
+		storedDuplicated, _ := repo.GetPlan(ctx, userId, duplicated.Id)
+		assert.Empty(t, storedDuplicated.Items)
+	})
+
+	t.Run("should not make duplicated plan current", func(t *testing.T) {
+		// given
+		ctx, repo, userId := setupTestRepository(t)
+		sourcePlan, _ := repo.CreatePlan(ctx, userId, BudgetPlan{Name: "Source Plan"})
+
+		// when
+		duplicated, _ := repo.DuplicatePlan(ctx, userId, sourcePlan.Id, "Duplicated Plan")
+
+		// then
+		storedDuplicated, _ := repo.GetPlan(ctx, userId, duplicated.Id)
+		assert.False(t, storedDuplicated.IsCurrent)
+		current, _ := repo.GetCurrentPlan(ctx, userId)
+		assert.Equal(t, sourcePlan.Id, current.Id)
+	})
+
+	t.Run("should return error when source plan does not exist", func(t *testing.T) {
+		// given
+		ctx, repo, userId := setupTestRepository(t)
+
+		// when
+		_, err := repo.DuplicatePlan(ctx, userId, 99999, "Non-existent")
+
+		// then
+		assert.ErrorIs(t, err, ErrPlanNotFound)
+		plans, _ := repo.ListPlans(ctx, userId)
+		assert.Empty(t, plans, "no plan should be created when source does not exist")
+	})
+
+	t.Run("should not duplicate plan owned by another user", func(t *testing.T) {
+		// given
+		ctx, repo, userId := setupTestRepository(t)
+		sourcePlan, _ := repo.CreatePlan(ctx, userId, BudgetPlan{Name: "User A Plan"})
+		repo.StoreItem(ctx, userId, BudgetItem{PlanId: sourcePlan.Id, Name: "User A Item", WeeklyDuration: time.Hour})
+		otherUserId := 2
+
+		// when
+		_, err := repo.DuplicatePlan(ctx, otherUserId, sourcePlan.Id, "User B Copy")
+
+		// then
+		assert.ErrorIs(t, err, ErrPlanNotFound)
+		otherPlans, _ := repo.ListPlans(ctx, otherUserId)
+		assert.Empty(t, otherPlans, "no plan should be created for the other user")
+	})
+}

--- a/pkg/budget_plan/service.go
+++ b/pkg/budget_plan/service.go
@@ -3,6 +3,7 @@ package budget_plan
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/klokku/klokku/internal/event_bus"
 	"github.com/klokku/klokku/pkg/user"
@@ -14,6 +15,7 @@ type Service interface {
 	GetCurrentPlan(ctx context.Context) (BudgetPlan, error)
 	ListPlans(ctx context.Context) ([]BudgetPlan, error)
 	CreatePlan(ctx context.Context, plan BudgetPlan) (BudgetPlan, error)
+	DuplicatePlan(ctx context.Context, sourcePlanId int, newName string) (BudgetPlan, error)
 	UpdatePlan(ctx context.Context, plan BudgetPlan) (BudgetPlan, error)
 	DeletePlan(ctx context.Context, planId int) (bool, error)
 	GetItem(ctx context.Context, id int) (BudgetItem, error)
@@ -62,6 +64,17 @@ func (s *ServiceImpl) CreatePlan(ctx context.Context, plan BudgetPlan) (BudgetPl
 		return BudgetPlan{}, fmt.Errorf("failed to get current user: %w", err)
 	}
 	return s.repo.CreatePlan(ctx, userId, plan)
+}
+
+func (s *ServiceImpl) DuplicatePlan(ctx context.Context, sourcePlanId int, newName string) (BudgetPlan, error) {
+	userId, err := user.CurrentId(ctx)
+	if err != nil {
+		return BudgetPlan{}, fmt.Errorf("failed to get current user: %w", err)
+	}
+	if strings.TrimSpace(newName) == "" {
+		return BudgetPlan{}, ErrPlanNameEmpty
+	}
+	return s.repo.DuplicatePlan(ctx, userId, sourcePlanId, newName)
 }
 
 func (s *ServiceImpl) UpdatePlan(ctx context.Context, plan BudgetPlan) (BudgetPlan, error) {

--- a/pkg/budget_plan/service_test.go
+++ b/pkg/budget_plan/service_test.go
@@ -2,6 +2,7 @@ package budget_plan
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -538,5 +539,128 @@ func TestServiceImpl_GetItem(t *testing.T) {
 		assert.Equal(t, item.WeeklyOccurrences, readItem.WeeklyOccurrences)
 		assert.Equal(t, item.Icon, readItem.Icon)
 		assert.Equal(t, item.Color, readItem.Color)
+	})
+}
+
+func TestServiceImpl_DuplicatePlan(t *testing.T) {
+	t.Run("should duplicate a plan with all its items", func(t *testing.T) {
+		teardown := setup(t)
+		defer teardown()
+
+		// given
+		sourcePlan, _ := service.CreatePlan(ctx, BudgetPlan{Name: "Source Plan"})
+		service.CreateItem(ctx, BudgetItem{
+			PlanId:            sourcePlan.Id,
+			Name:              "Item 1",
+			WeeklyDuration:    time.Duration(2) * time.Hour,
+			WeeklyOccurrences: 3,
+			Icon:              "SomeIcon",
+			Color:             "#FF0000",
+		})
+		service.CreateItem(ctx, BudgetItem{
+			PlanId:            sourcePlan.Id,
+			Name:              "Item 2",
+			WeeklyDuration:    time.Duration(4) * time.Hour,
+			WeeklyOccurrences: 5,
+			Icon:              "OtherIcon",
+			Color:             "#00FF00",
+		})
+
+		// when
+		duplicatedPlan, err := service.DuplicatePlan(ctx, sourcePlan.Id, "Duplicated Plan")
+
+		// then
+		assert.NoError(t, err)
+		assert.NotEqual(t, sourcePlan.Id, duplicatedPlan.Id)
+		assert.Equal(t, "Duplicated Plan", duplicatedPlan.Name)
+		assert.False(t, duplicatedPlan.IsCurrent)
+
+		duplicated, _ := service.GetPlan(ctx, duplicatedPlan.Id)
+		assert.Len(t, duplicated.Items, 2)
+		assert.Equal(t, "Item 1", duplicated.Items[0].Name)
+		assert.Equal(t, time.Duration(2)*time.Hour, duplicated.Items[0].WeeklyDuration)
+		assert.Equal(t, 3, duplicated.Items[0].WeeklyOccurrences)
+		assert.Equal(t, "SomeIcon", duplicated.Items[0].Icon)
+		assert.Equal(t, "#FF0000", duplicated.Items[0].Color)
+		assert.Equal(t, "Item 2", duplicated.Items[1].Name)
+		assert.Equal(t, time.Duration(4)*time.Hour, duplicated.Items[1].WeeklyDuration)
+		assert.Equal(t, 5, duplicated.Items[1].WeeklyOccurrences)
+		assert.Equal(t, "OtherIcon", duplicated.Items[1].Icon)
+		assert.Equal(t, "#00FF00", duplicated.Items[1].Color)
+	})
+
+	t.Run("should duplicate a plan with no items", func(t *testing.T) {
+		teardown := setup(t)
+		defer teardown()
+
+		// given
+		sourcePlan, _ := service.CreatePlan(ctx, BudgetPlan{Name: "Empty Plan"})
+
+		// when
+		duplicatedPlan, err := service.DuplicatePlan(ctx, sourcePlan.Id, "Duplicated Empty Plan")
+
+		// then
+		assert.NoError(t, err)
+		assert.NotEqual(t, sourcePlan.Id, duplicatedPlan.Id)
+		assert.Equal(t, "Duplicated Empty Plan", duplicatedPlan.Name)
+
+		duplicated, _ := service.GetPlan(ctx, duplicatedPlan.Id)
+		assert.Len(t, duplicated.Items, 0)
+	})
+
+	t.Run("should not make duplicated plan current", func(t *testing.T) {
+		teardown := setup(t)
+		defer teardown()
+
+		// given
+		sourcePlan, _ := service.CreatePlan(ctx, BudgetPlan{Name: "Source Plan"})
+
+		// when
+		duplicatedPlan, _ := service.DuplicatePlan(ctx, sourcePlan.Id, "Duplicated Plan")
+
+		// then
+		currentPlan, err := service.GetCurrentPlan(ctx)
+		assert.NoError(t, err)
+		assert.NotEqual(t, duplicatedPlan.Id, currentPlan.Id)
+		assert.Equal(t, sourcePlan.Id, currentPlan.Id)
+	})
+
+	t.Run("should return error when source plan does not exist", func(t *testing.T) {
+		teardown := setup(t)
+		defer teardown()
+
+		// when
+		_, err := service.DuplicatePlan(ctx, 999, "Non-existent Plan")
+
+		// then
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrPlanNotFound))
+	})
+
+	t.Run("should return error when name is empty", func(t *testing.T) {
+		teardown := setup(t)
+		defer teardown()
+
+		// given
+		plan, _ := service.CreatePlan(ctx, BudgetPlan{Name: "Source Plan"})
+
+		// when
+		_, err := service.DuplicatePlan(ctx, plan.Id, "")
+
+		// then
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrPlanNameEmpty))
+	})
+
+	t.Run("should return error when context has no user", func(t *testing.T) {
+		teardown := setup(t)
+		defer teardown()
+
+		// when
+		_, err := service.DuplicatePlan(context.Background(), 1, "Test")
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get current user")
 	})
 }


### PR DESCRIPTION
## What
Add a server-side, atomic endpoint to duplicate an existing budget plan with all its items.

## Endpoint
```
POST /api/budgetplan/{planId}/duplicate
Body: { "name": "<new plan name>" }
Response: 201 Created with BudgetPlanDTO
```

## What is copied
- `budget_plan` row (new id, new name, same `user_id`)

## What is deliberately NOT copied
- `budget_plan_current` - duplicated plan is non-current
- `weekly_plan` / `weekly_plan_item` - per-week runtime data
- `clickup_config` / `clickup_tag_mapping` - plan-specific integration config
- `calendar_event` / `current_event` - runtime event data

## Changes
- `pkg/budget_plan/repository.go`: `DuplicatePlan` on `Repository` interface + `RepositoryImpl` implementation (single transaction: ownership check -> insert plan row -> INSERT...SELECT items)
- `pkg/budget_plan/repository_stub.go`: `DuplicatePlan` stub
- `pkg/budget_plan/service.go`: `DuplicatePlan` on `Service` interface + implementation (userId resolution, name validation)
- `pkg/budget_plan/handler.go`: `DuplicatePlan` HTTP handler with proper status codes (201, 400, 404, 500)
- `internal/app/routes.go`: route registration

## Tests
- `service_test.go`: 6 stub-based cases (happy path, empty plan, non-current invariant, not-found, empty name, missing user context)
- `repository_test.go`: 5 testcontainers-based cases (happy path, empty plan, non-current, not-found, cross-user ownership check)

## Security
Ownership check `SELECT true FROM budget_plan WHERE id = $1 AND user_id = $2` prevents duplicating another user's plan; returns `ErrPlanNotFound` otherwise.